### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Build & Publish to Registry
         id: build-and-publish
-        uses: elgohr/Publish-Docker-Github-Action@191af57e15535d28b83589e3b5f0c31e76aa8733
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: qminder/github-action-ktlint
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore